### PR TITLE
Fix default recipe and modify default template

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,7 +5,10 @@
 # Copyright (c) 2016, David Joos
 #
 
-default['beanstalkd']['opts'] = {}
+default['beanstalkd']['opts'] = {
+	:p => '11300',
+ 	 :l => '127.0.0.1'
+}
 
 # Ubuntu only
 default['beanstalkd']['start_during_boot'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,10 +5,7 @@
 # Copyright (c) 2016, David Joos
 #
 
-default['beanstalkd']['opts'] = {
-	:p => '11300',
- 	 :l => '127.0.0.1'
-}
+default['beanstalkd']['opts'] = {}
 
 # Ubuntu only
 default['beanstalkd']['start_during_boot'] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,33 +6,32 @@
 #
 
 package 'beanstalkd' do
-  action :upgrade
+	action :upgrade
 end
 
 case node['platform']
 when 'debian', 'ubuntu'
-  template_path = '/etc/default/beanstalkd' # templates/ubuntu
+	template_path = '/etc/default/beanstalkd' # templates/ubuntu
 else
-  template_path = '/etc/sysconfig/beanstalkd' # templates/default
+	template_path = '/etc/sysconfig/beanstalkd' # templates/default
 end
 
 template template_path do
-  source 'beanstalkd.erb'
-  owner 'root'
-  group 'root'
-  mode 0644
-  variables(
-    :opts => node['beanstalkd']['opts'],
-    :start_during_boot => node['beanstalkd']['start_during_boot']
-  )
-  notifies :restart, 'service[beanstalkd]'
+	source 'beanstalkd.erb'
+	owner 'root'
+	group 'root'
+	mode 0644
+	variables(
+		:opts => node['beanstalkd']['opts'],
+		:start_during_boot => node['beanstalkd']['start_during_boot']
+	)
+	notifies :restart, 'service[beanstalkd]'
 end
 
+
 service 'beanstalkd' do
-  start_command '/etc/init.d/beanstalkd start'
-  stop_command '/etc/init.d/beanstalkd stop'
-  status_command '/etc/init.d/beanstalkd status'
-  supports [:start, :stop, :status]
-  # starts the service if it's not running and enables it to start at system boot time
-  action [:enable, :start]
+	supports [:start, :stop, :status]
+	# starts the service if it's not running and enables it to start at system boot time
+	action [:enable, :start]
 end
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,32 +6,32 @@
 #
 
 package 'beanstalkd' do
-	action :upgrade
+  action :upgrade
 end
 
 case node['platform']
 when 'debian', 'ubuntu'
-	template_path = '/etc/default/beanstalkd' # templates/ubuntu
+  template_path = '/etc/default/beanstalkd' # templates/ubuntu
 else
-	template_path = '/etc/sysconfig/beanstalkd' # templates/default
+  template_path = '/etc/sysconfig/beanstalkd' # templates/default
 end
 
 template template_path do
-	source 'beanstalkd.erb'
-	owner 'root'
-	group 'root'
-	mode 0644
-	variables(
-		:opts => node['beanstalkd']['opts'],
-		:start_during_boot => node['beanstalkd']['start_during_boot']
-	)
-	notifies :restart, 'service[beanstalkd]'
+  source 'beanstalkd.erb'
+  owner 'root'
+  group 'root'
+  mode 0644
+  variables(
+    :opts => node['beanstalkd']['opts'],
+    :start_during_boot => node['beanstalkd']['start_during_boot']
+  )
+  notifies :restart, 'service[beanstalkd]'
 end
 
 
 service 'beanstalkd' do
-	supports [:start, :stop, :status]
-	# starts the service if it's not running and enables it to start at system boot time
-	action [:enable, :start]
+  supports [:start, :stop, :status]
+  # starts the service if it's not running and enables it to start at system boot time
+  action [:enable, :start]
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,10 +28,8 @@ template template_path do
   notifies :restart, 'service[beanstalkd]'
 end
 
-
 service 'beanstalkd' do
   supports [:start, :stop, :status]
   # starts the service if it's not running and enables it to start at system boot time
   action [:enable, :start]
 end
-

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -1,24 +1,21 @@
 require 'spec_helper'
 
 describe 'beanstalkd::default' do
-  let(:chef_run) { 
-    ChefSpec::Runner.new.converge(described_recipe)
-   }
+  let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
 
-   it 'should upgrade the beanstalkd' do 
-      expect(chef_run).to upgrade_package('beanstalkd')
-   end
+  it 'should upgrade the beanstalkd' do
+    expect(chef_run).to upgrade_package('beanstalkd')
+  end
 
-   it 'should deploy the beanstalkd template' do 
-      expect(chef_run).to create_template('/etc/sysconfig/beanstalkd').with(user: 'root')
+  it 'should deploy the beanstalkd template' do
+    expect(chef_run).to create_template('/etc/sysconfig/beanstalkd')
+  end
 
-   end
+  it 'must enable the beanstalkd service' do
+    expect(chef_run).to enable_service('beanstalkd')
+  end
 
-   it 'must enable the beanstalkd service' do 
-      expect(chef_run).to enable_service('beanstalkd')
-   end
-
-   it 'should start the beanstalkd service' do 
-      expect(chef_run).to start_service('beanstalkd')
-   end
+  it 'should start the beanstalkd service' do
+    expect(chef_run).to start_service('beanstalkd')
+  end
 end

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -1,5 +1,24 @@
 require 'spec_helper'
 
 describe 'beanstalkd::default' do
-  let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+	let(:chef_run) { 
+		ChefSpec::Runner.new.converge(described_recipe)
+	 }
+
+	 it 'should upgrade the beanstalkd' do 
+	 	expect(chef_run).to upgrade_package('beanstalkd')
+	 end
+
+	 it 'should deploy the beanstalkd template' do 
+	 	expect(chef_run).to create_template('/etc/sysconfig/beanstalkd').with(user: 'root')
+
+	 end
+
+	 it 'must enable the beanstalkd service' do 
+	 	expect(chef_run).to enable_service('beanstalkd')
+	 end
+
+	 it 'should start the beanstalkd service' do 
+	 	expect(chef_run).to start_service('beanstalkd')
+	 end
 end

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -1,24 +1,24 @@
 require 'spec_helper'
 
 describe 'beanstalkd::default' do
-	let(:chef_run) { 
-		ChefSpec::Runner.new.converge(described_recipe)
-	 }
+  let(:chef_run) { 
+    ChefSpec::Runner.new.converge(described_recipe)
+   }
 
-	 it 'should upgrade the beanstalkd' do 
-	 	expect(chef_run).to upgrade_package('beanstalkd')
-	 end
+   it 'should upgrade the beanstalkd' do 
+      expect(chef_run).to upgrade_package('beanstalkd')
+   end
 
-	 it 'should deploy the beanstalkd template' do 
-	 	expect(chef_run).to create_template('/etc/sysconfig/beanstalkd').with(user: 'root')
+   it 'should deploy the beanstalkd template' do 
+      expect(chef_run).to create_template('/etc/sysconfig/beanstalkd').with(user: 'root')
 
-	 end
+   end
 
-	 it 'must enable the beanstalkd service' do 
-	 	expect(chef_run).to enable_service('beanstalkd')
-	 end
+   it 'must enable the beanstalkd service' do 
+      expect(chef_run).to enable_service('beanstalkd')
+   end
 
-	 it 'should start the beanstalkd service' do 
-	 	expect(chef_run).to start_service('beanstalkd')
-	 end
+   it 'should start the beanstalkd service' do 
+      expect(chef_run).to start_service('beanstalkd')
+   end
 end

--- a/templates/default/beanstalkd.erb
+++ b/templates/default/beanstalkd.erb
@@ -9,29 +9,29 @@
 # Available options correspond to the options to the
 # beanstalkd commandline.
 
-BEANSTALKD_ADDR=<% if @opts['l'].nil? %>0.0.0.0<% else %><%= @opts['l'] %><% end %>
-BEANSTALKD_PORT=<% if @opts['p'].nil? %>11300<% else %><%= @opts['p'] %><% end %>
-BEANSTALKD_USER=<% if @opts['u'].nil? %>beanstalkd<% else %><%= @opts['u'] %><% end %>
+ADDR= -l <% if @opts['l'].nil? %>0.0.0.0<% else %><%= @opts['l'] %><% end %>
+PORT= -p <% if @opts['p'].nil? %>11300<% else %><%= @opts['p'] %><% end %>
+USER= -u <% if @opts['u'].nil? %>beanstalkd<% else %><%= @opts['u'] %><% end %>
 
 # Job size is left to the default. Uncomment and set it
 # to a value to have it take affect.
-<% unless @opts['z'] %>#<% end %>BEANSTALKD_MAX_JOB_SIZE=<% if @opts['z'].nil? %>65535<% else %><%= @opts['z'] %><% end %>
+<% unless @opts['z'] %>#<% end %>MAX_JOB_SIZE= -z <% if @opts['z'].nil? %>65535<% else %><%= @opts['z'] %><% end %>
 
 # Using the binlog is off by default.
 #
 # The direcory to house the binlog.
-<% unless @opts['b'] %>#<% end %>BEANSTALKD_BINLOG_DIR=<% if @opts['b'].nil? %>/var/lib/beanstalkd/binlog<% else %><%= @opts['b'] %><% end %>
+<% unless @opts['b'] %>#<% end %>$BINLOG_DIR= -b <% if @opts['b'].nil? %>/var/lib/beanstalkd/binlog<% else %><%= @opts['b'] %><% end %>
 
 #
 # fsync the binlog at most once every N milliseconds.
 # setting this to 0 means 'always fsync'. If this is unset,
 # and the binlog is used, then no explicit fsync is ever
 # performed.  That is, the -F option is used.
-<% unless @opts['f'] %>#<% end %>BEANSTALKD_BINLOG_FSYNC_PERIOD=<% if @opts['f'].nil? %><% else %><%= @opts['f'] %><% end %>
+<% unless @opts['f'] %>#<% end %>BINLOG_FSYNC_PERIOD= -f <% if @opts['f'].nil? %><% else %><%= @opts['f'] %><% end %>
 
 #
 # The size of each binlog file.  This is rounded
 # up to the nearest 512 byte boundary.
-<% unless @opts['s'] %>#<% end %>BEANSTALKD_BINLOG_SIZE=<% if @opts['s'].nil? %>10485760<% else %><%= @opts['s'] %><% end %>
+<% unless @opts['s'] %>#<% end %>BINLOG_SIZE= -s <% if @opts['s'].nil? %>10485760<% else %><%= @opts['s'] %><% end %>
 
 <% unless @start_during_boot %>#<% end %>START=yes


### PR DESCRIPTION
Hi @djoos,

I created a pull request and I am very happy to contribute in this project so that I can help others.

### Changes made

Re-implemented the `service resource` of beanstalkd in the default recipe. I got in error after the execution of `kitchen verify` that `/etc/init.d/beanstalkd` does not exists. This is the error log:
```
Error executing action `enable` on resource 'service[beanstalkd]'
           ================================================================================

           Errno::ENOENT
           -------------
           No such file or directory - /etc/init.d/beanstalkd
```
 
I modified the default`beanstalkd.erb` because I got an error status when I executed `systemctl status beanstalkd`. This is the error log:
```
[vagrant@default-centos-72 ~]$ systemctl status beanstalkd
● beanstalkd.service - Beanstalkd Fast Workqueue Service
   Loaded: loaded (/usr/lib/systemd/system/beanstalkd.service; enabled; vendor preset: disabled)
   Active: failed (Result: start-limit) since Wed 2016-12-14 16:26:16 UTC; 1min 28s ago
  Process: 12278 ExecStart=/usr/bin/beanstalkd $ADDR $PORT $USER $MAX_JOB_SIZE $BINLOG_DIR $BINLOG_SIZE $BINLOG_FSYNC_PERIOD (code=exited, status=5)
```
I added flags like `-f`, `-l`, `-p`, and others so that it will work. This is the sample change that I made to default template.
```
ADDR= -l <% if @opts['l'].nil? %>0.0.0.0<% else %><%= @opts['l'] %><% end %>
```
I added `ChefSpec` tests for the `beanstalkd` default recipe.

Thanks,
Michael
