### PR TITLE
allow defining BEANSTALKD_LISTEN_PORT for ubuntu based on opts

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'development@davidjoos.com'
 license 'MIT'
 description 'Installs/Configures beanstalkd'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.3.0'
+version '0.3.2'
 
 %w(debian ubuntu redhat centos fedora scientific amazon).each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,6 @@ end
 
 source_url 'https://github.com/djoos-cookbooks/beanstalkd' if respond_to?(:source_url)
 issues_url 'https://github.com/djoos-cookbooks/beanstalkd/issues' if respond_to?(:issues_url)
-depends 'php'
-depends 'python'
+
 
 recipe 'beanstalkd', 'Installs beanstalkd.'

--- a/templates/ubuntu/beanstalkd.erb
+++ b/templates/ubuntu/beanstalkd.erb
@@ -8,6 +8,7 @@
 ## Debian systems. Append ``-b /var/lib/beanstalkd'' for persistent
 ## storage.
 BEANSTALKD_LISTEN_ADDR="<%= @listen_addr %>"
+BEANSTALKD_LISTEN_PORT=<% if @opts['p'].nil? %>11300<% else %><%= @opts['p'] %><% end %>
 BEANSTALKD_EXTRA="<% @opts.each do |k,v| %><%= "-#{k} #{v}" %> <% end %>"
 DAEMON_OPTS=$BEANSTALKD_EXTRA
 


### PR DESCRIPTION
on ubuntu 16.04, I'm finding that I can't actually access beanstalk without this.